### PR TITLE
Upgrade Phlex to 0.5

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,8 +1,10 @@
 GIT
   remote: https://github.com/joeldrapper/phlex.git
-  revision: e3a40e5956b0814dba6684cc414ed55c73a37950
+  revision: 16edeba653fa0126eaa593d75acf98fb2f33d786
   specs:
-    phlex (0.2.1)
+    phlex (0.5.0)
+      hescape
+      syntax_tree (~> 3.6)
       zeitwerk (~> 2.6)
 
 GEM
@@ -81,17 +83,17 @@ GEM
     crass (1.0.6)
     cssbundling-rails (1.1.1)
       railties (>= 6.0.0)
-    debug (1.6.2)
+    debug (1.6.3)
       irb (>= 1.3.6)
       reline (>= 0.3.1)
-    digest (3.1.0)
     erubi (1.11.0)
     globalid (1.0.0)
       activesupport (>= 5.0)
+    hescape (0.1.1)
     i18n (1.12.0)
       concurrent-ruby (~> 1.0)
     io-console (0.5.11)
-    irb (1.4.1)
+    irb (1.4.2)
       reline (>= 0.3.0)
     jsbundling-rails (1.0.3)
       railties (>= 6.0.0)
@@ -104,31 +106,26 @@ GEM
     method_source (1.0.0)
     mini_mime (1.1.2)
     minitest (5.16.3)
-    msgpack (1.5.6)
-    net-imap (0.2.3)
-      digest
+    msgpack (1.6.0)
+    net-imap (0.3.1)
       net-protocol
-      strscan
-    net-pop (0.1.1)
-      digest
+    net-pop (0.1.2)
       net-protocol
-      timeout
     net-protocol (0.1.3)
       timeout
-    net-smtp (0.3.1)
-      digest
+    net-smtp (0.3.3)
       net-protocol
-      timeout
     nio4r (2.5.8)
-    nokogiri (1.13.8-arm64-darwin)
+    nokogiri (1.13.9-arm64-darwin)
       racc (~> 1.4)
-    nokogiri (1.13.8-x86_64-darwin)
+    nokogiri (1.13.9-x86_64-darwin)
       racc (~> 1.4)
-    nokogiri (1.13.8-x86_64-linux)
+    nokogiri (1.13.9-x86_64-linux)
       racc (~> 1.4)
     pagy (5.10.1)
       activesupport
-    pg (1.4.3)
+    pg (1.4.4)
+    prettier_print (1.1.0)
     propshaft (0.6.4)
       actionpack (>= 7.0.0)
       activesupport (>= 7.0.0)
@@ -174,19 +171,20 @@ GEM
     redis (4.8.0)
     reline (0.3.1)
       io-console (~> 0.5)
-    stimulus-rails (1.1.0)
+    stimulus-rails (1.1.1)
       railties (>= 6.0.0)
-    strscan (3.0.4)
+    syntax_tree (3.6.3)
+      prettier_print
     thor (1.2.1)
     timeout (0.3.0)
-    turbo-rails (1.3.0)
+    turbo-rails (1.3.2)
       actionpack (>= 6.0.0)
       activejob (>= 6.0.0)
       railties (>= 6.0.0)
-    turbo_power (0.1.2)
+    turbo_power (0.1.5)
       turbo-rails (~> 1.3.0)
       turbo_ready
-    turbo_ready (0.1.0)
+    turbo_ready (0.1.2)
       rails (>= 6.1)
       turbo-rails (>= 1.1)
     tzinfo (2.0.5)
@@ -199,7 +197,7 @@ GEM
     websocket-driver (0.7.5)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
-    zeitwerk (2.6.0)
+    zeitwerk (2.6.6)
 
 PLATFORMS
   arm64-darwin-21

--- a/app/components/application_component.rb
+++ b/app/components/application_component.rb
@@ -1,6 +1,6 @@
 require "phlex/rails"
 
-class ApplicationComponent < Phlex::Component
+class ApplicationComponent < Phlex::HTML
   include ActionView::Helpers::AssetUrlHelper
   include ActionView::RecordIdentifier
   include Rails.application.routes.url_helpers
@@ -10,7 +10,7 @@ class ApplicationComponent < Phlex::Component
 
   class Struct
     private
-    
+
     def tokens(*tokens, **conditional_tokens)
       conditional_tokens.each do |condition, token|
         case condition
@@ -19,7 +19,7 @@ class ApplicationComponent < Phlex::Component
         else raise ArgumentError,
                     "The class condition must be a Symbol or a Proc."
         end
-    
+
         case token
         when Symbol then tokens << token.name
         when String then tokens << token
@@ -28,7 +28,7 @@ class ApplicationComponent < Phlex::Component
                     "Conditional classes must be Symbols, Strings, or Arrays of Symbols or Strings."
         end
       end
-    
+
       tokens.compact.join(" ")
     end
   end
@@ -40,7 +40,7 @@ class ApplicationComponent < Phlex::Component
       memo.deep_merge(attribute_hash) do |attribute, oldval, newval|
         next newval unless ["class", "data-controller", "data-action"].include?(attribute)
         next newval if attribute.end_with?("!")
-      
+
         [oldval, newval].uniq.join(' ')
       end
     end

--- a/app/components/menu_component.rb
+++ b/app/components/menu_component.rb
@@ -34,39 +34,33 @@ class MenuComponent < ApplicationComponent
     @align = align
     @attributes = attributes
   end
-  
+
   def template(&)
     render PopoverComponent.new(role: :menu, side: @side, align: @align, **attributify(struct.root, @attributes)) do |popover|
       @popover = popover
 
-      content(&)
+      yield_content(&)
     end
   end
-  
+
   def trigger(**attributes, &)
-    @popover.trigger **attributify(struct.trigger, button.base, attributes) do
-      content(&)
-    end
+    @popover.trigger(**attributify(struct.trigger, button.base, attributes), &)
   end
-  
+
   def portal(**attributes, &)
-    @popover.portal **attributify(struct.portal, attributes) do
-      content(&)
-    end
+    @popover.portal(**attributify(struct.portal, attributes), &)
   end
-  
+
   def group(&)
-    div class: "py-1" do
-      content(&)
-    end
+    div(class: "py-1", &)
   end
-  
+
   def struct
     self.class.struct()
   end
-  
+
   private
-  
+
   def button
     ButtonComponent.struct
   end

--- a/app/components/menu_item_component.rb
+++ b/app/components/menu_item_component.rb
@@ -11,7 +11,7 @@ class MenuItemComponent < ApplicationComponent
       }
     end
   end
-  
+
   def self.struct(*args, **kwargs)
     Struct.new(*args, **kwargs)
   end
@@ -27,7 +27,7 @@ class MenuItemComponent < ApplicationComponent
   def template(&)
     public_send(@element, **menuitem_attributes) do
       render Bootstrap::IconComponent.new(@icon) if @icon
-      @text ? span(@text) : content(&)
+      @text ? span { @text } : yield_content(&)
     end
   end
 

--- a/app/components/popover_component.rb
+++ b/app/components/popover_component.rb
@@ -22,14 +22,14 @@ class PopoverComponent < ApplicationComponent
       @align = align
       @popover_id = "popover-#{@role}-#{object_id}"
     end
-    
+
     def root
       {
         class: "relative group",
         data: { controller: "details-popover" }
       }
     end
-    
+
     def trigger
       {
         class: tokens("marker:hidden cursor-pointer h-full"),
@@ -44,7 +44,7 @@ class PopoverComponent < ApplicationComponent
         },
       }
     end
-    
+
     def portal
       {
         id: @popover_id,
@@ -69,9 +69,9 @@ class PopoverComponent < ApplicationComponent
         ),
       }
     end
-    
+
     private
-    
+
     def side_top? = @side == :top
     def side_bottom? = @side == :bottom
     def side_left? = @side == :left
@@ -104,16 +104,14 @@ class PopoverComponent < ApplicationComponent
     @popover_id = "details-popover-#{@role}-#{object_id}"
   end
 
-  def template(&)
-    details **attributify(struct.root, @attributes) do
-      content(&)
-    end
+  def template(&block)
+    details(**attributify(struct.root, @attributes), &block)
   end
 
   def trigger(icon: true, **attributes, &block)
-    summary **struct.trigger do
-      div **attributify({class: "h-full"}, attributes) do
-        content(&block)
+    summary(**struct.trigger) do
+      div(**attributify({class: "h-full"}, attributes)) do
+        yield_content(&block)
 
         render trigger_icon(icon) if icon
       end
@@ -121,7 +119,7 @@ class PopoverComponent < ApplicationComponent
   end
 
   def portal(**attributes, &block)
-    div **attributify(struct.portal, attributes), &block
+    div(**attributify(struct.portal, attributes), &block)
   end
 
   def struct

--- a/app/views/books/form/section.rb
+++ b/app/views/books/form/section.rb
@@ -13,14 +13,14 @@ module Views
       render PopoverComponent.new(align: :end, class: "inline-block text-left z-30", id: @id, **attributes) do |popover|
         @popover = popover
 
-        content(&)
+        yield_content(&)
       end
     end
 
     def title(icon:, colored: false, classes: {}, &block)
       @popover.trigger **classes("inline-flex items-center justify-center gap-2 w-full rounded-md border-2 border-transparent bg-white px-4 py-2 font-medium text-gray-700 focus:ring-offset-gray-100", -> { colored } => classes, -> { !colored } => "group-open:border-gray-200 hover:border-gray-300") do
         render Bootstrap::IconComponent.new(icon, class: "text-xl")
-      
+
         span class: "whitespace-nowrap", &block
       end
     end

--- a/app/views/books/index.rb
+++ b/app/views/books/index.rb
@@ -34,7 +34,7 @@ module Views
     def headline
       header class: "shrink text-white px-4 py-2 flex items-center justify-between" do
         a class: "min-w-0", href: root_path do
-          h2 "Workspace", class: "text-xl font-bold leading-7 sm:truncate sm:text-2xl sm:tracking-tight"
+          h2(class: "text-xl font-bold leading-7 sm:truncate sm:text-2xl sm:tracking-tight") { "Workspace" }
         end
         div class: "mt-4 flex items-center md:mt-0 md:ml-4" do
           svg width: "40", height: "40", viewBox: "0 0 280 300", fill: "white", xmlns: "http://www.w3.org/2000/svg" do
@@ -42,7 +42,7 @@ module Views
             path d: "M146 154.12v68.19a4.59 4.59 0 0 0 6.29 4.27L229 196.81a4.6 4.6 0 0 0 2.9-4.27v-68.2a4.6 4.6 0 0 0-6.29-4.27l-76.71 29.78a4.58 4.58 0 0 0-2.9 4.27"
             path d: "m128.13 157.64-22.77 11-2.31 1.11-48 23c-3 1.47-6.94-.75-6.94-4.13v-64a4.29 4.29 0 0 1 1.47-3.08 5.33 5.33 0 0 1 1.16-.87 4.9 4.9 0 0 1 4.18-.32l72.88 28.87a4.6 4.6 0 0 1 .38 8.41"
           end
-          span "HotTable"
+          span { "HotTable" }
         end
       end
     end

--- a/app/views/books/tab.rb
+++ b/app/views/books/tab.rb
@@ -13,7 +13,7 @@ module Views
             div class: "block group-has-peer-checked:hidden divide-y divide-gray-100" do
               div class: "py-1" do
                 render MenuItemComponent.new(as: :label, for: @rename_id, icon: "pencil") do
-                  span "Rename view"
+                  span { "Rename view" }
                   input id: @rename_id, type: "checkbox", checked: false, class: "sr-only peer"
                 end
                 render MenuItemComponent.new(as: :button, type: "submit", form: "searchForm", formaction: view_path(@view.id), class: "w-full", icon: "sliders2", text: "Update view")
@@ -22,7 +22,7 @@ module Views
                 div class: "py-1" do
                   a href: view_path(@view.id), class: "text-gray-700 group flex items-center px-4 py-2 space-x-2 hover:bg-red-200 hover:text-red-700", role: "menuitem", tabindex: "-1", data_turbo_method: "delete" do
                     render Bootstrap::IconComponent.new("trash")
-                    span "Delete view"
+                    span { "Delete view" }
                   end
                 end
               end
@@ -30,12 +30,12 @@ module Views
 
             div class: "hidden group-has-peer-checked:block" do
               div class: "p-2" do
-                label "Name", for: "views_name", class: "block text-sm font-medium text-gray-700"
+                label(for: "views_name", class: "block text-sm font-medium text-gray-700") { "Name" }
                 div class: "mt-1" do
                   input type: "text", value: @view.name, name: "views[#{@view.id}][name]", form: "searchForm", id: "views_name", class: "block w-full text-gray-900 rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500 sm:text-sm", placeholder: "e.g. 20th century English novels"
                 end
               end
-              
+
               div class: "flex items-center justify-end gap-2 py-2 px-4 bg-gray-200" do
                 input type: "submit", value: "Save", form: "searchForm", formaction: view_path(@view.id), class: "inline-flex items-center rounded-md border border-transparent bg-blue-500 hover:bg-blue-400 text-white px-2.5 py-1.5 text-base font-medium text-gray-900 gap-2"
               end
@@ -47,7 +47,7 @@ module Views
           **classes("relative z-40 group rounded-t inline-flex items-center font-medium text-white border-b border-transparent px-4 py-2 hover:border-white hover:bg-violet-900",
             current_page?: "bg-white text-gray-800 hover:bg-gray-100"),
           aria_current: tokens(current_page?: "page") do
-          span @view.name
+          span { @view.name }
         end
       end
     end

--- a/app/views/books/tab_popover.rb
+++ b/app/views/books/tab_popover.rb
@@ -14,15 +14,13 @@ module Views
           render Bootstrap::IconComponent.new(@icon) if @icon
           text @title
         end
-        
-        content(&)
+
+        yield_content(&)
       end
     end
 
-    def body(&block)
-      @popover.portal **popover_portal_attributes do
-        content(&block)
-      end
+    def body(&)
+      @popover.portal(**popover_portal_attributes, &)
     end
 
     private

--- a/app/views/books/tabs.rb
+++ b/app/views/books/tabs.rb
@@ -8,45 +8,45 @@ module Views
       mobile_select
       desktop_tabs
     end
-    
+
     private
-    
+
     def mobile_select
       div class: "sm:hidden px-2 space-y-2 mb-2" do
-        label "Select a tab", for: "tabs", class: "sr-only"
+        label(for: "tabs", class: "sr-only"){ "Select a tab" }
         select id: "tabs", name: "tabs", class: "block w-full rounded-md border-gray-300 focus:border-blue-500 focus:ring-blue-500" do
           @views.each do |view|
-            option view.name, selected: params[:current_view] == view.name || params[:current_view].nil? && view.name == "Books"
+            option(selected: params[:current_view] == view.name || params[:current_view].nil? && view.name == "Books"){ view.name }
           end
         end
         render ButtonComponent.new("New view", icon: "plus-lg", class: "w-full flex")
       end
     end
-    
+
     def desktop_tabs
       div class: "hidden sm:block border-b border-gray-200" do
         nav id: "book_tabs", class: "-mb-px flex space-x-0.5 px-4", 'aria-label': "Tabs", data_controller: "details-set" do
           @views.each do |view|
             render Books::Tab.new(view)
           end
-      
+
           div id: "new_tab"
-      
+
           new_view_tab_popover
         end
       end
     end
-    
+
     def new_view_tab_popover
       render(Books::TabPopover.new("New view", icon: "plus-lg")) do |t|
         t.body do
           div class: "p-2" do
-            label "Name", for: "views_name", class: "block text-sm font-medium text-gray-700"
+            label(for: "views_name", class: "block text-sm font-medium text-gray-700") { "Name" }
             div class: "mt-1" do
               input type: "text", name: "views[name]", form: "searchForm", id: "views_name", class: "block w-full text-gray-900 rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500 sm:text-sm", placeholder: "e.g. 20th century English novels"
             end
           end
-      
+
           div class: "flex items-center justify-end gap-2 py-2 px-4 bg-gray-200" do
             render ButtonComponent.new(as: :input, type: "submit", value: "Save", form: "searchForm", formaction: views_path, primary: true)
           end

--- a/app/views/layout.rb
+++ b/app/views/layout.rb
@@ -1,5 +1,6 @@
 module Views
   class Layout < ApplicationComponent
+    include Phlex::Rails::Layout
     include Propshaft::Helper
     include ActionView::Helpers::AssetTagHelper
 
@@ -8,7 +9,7 @@ module Views
 
       html do
         head do
-          title "HotTable"
+          title { "HotTable" }
           meta name: "viewport", content: "width=device-width, initial-scale=1"
           csp_meta_tag
           csrf_meta_tags
@@ -27,9 +28,7 @@ module Views
             defer: "defer"
         end
 
-        body do
-          content(&)
-        end
+        body(&)
       end
     end
   end

--- a/app/views/table/column.rb
+++ b/app/views/table/column.rb
@@ -36,7 +36,7 @@ module Views
 
       def cell
         if @attribute.to_s == Book.primary_attribute.to_s
-          th scope: "row",
+          th(scope: "row",
              **classes("cursor-pointer text-sm font-medium text-gray-900 text-left sticky left-[calc(3rem+1px)] row-group-has-checked:text-blue-900",
                  filtered?: "bg-green-100 row-group-hover:bg-gray-green-100-mixed row-group-has-checked:bg-blue-green-100-mixed",
                  sorted?: "bg-orange-100 row-group-hover:bg-gray-orange-100-mixed row-group-has-checked:bg-blue-orange-100-mixed",
@@ -53,11 +53,11 @@ module Views
                   attribute_type: attribute_type,
                   edit_url: edit_book_path(@record),
                 },
-                style: "max-width: #{attribute_schema.fetch(:width, "initial")}" do
+                style: "max-width: #{attribute_schema.fetch(:width, "initial")}") do
             body
           end
         else
-          td **classes("text-sm text-gray-500 cursor-pointer whitespace-nowrap text-ellipsis overflow-hidden",
+          td(**classes("text-sm text-gray-500 cursor-pointer whitespace-nowrap text-ellipsis overflow-hidden",
                 filtered?: "bg-green-100 row-group-hover:bg-gray-green-100-mixed row-group-has-checked:bg-green-100/50",
                 sorted?: "bg-orange-100 row-group-hover:bg-gray-orange-100-mixed row-group-has-checked:bg-orange-100/50",
                 grouped?: "bg-purple-100 row-group-hover:bg-gray-purple-100-mixed row-group-has-checked:bg-purple-100/50",
@@ -72,18 +72,17 @@ module Views
                   attribute_type: attribute_type,
                   edit_url: edit_book_path(@record),
                 },
-                style: "max-width: #{attribute_schema.fetch(:width, "initial")}" do
+                style: "max-width: #{attribute_schema.fetch(:width, "initial")}") do
             body
           end
         end
       end
 
       def body
-        return div(number_with_precision(value, precision: Book.columns_hash[@attribute].sql_type_metadata.scale), class: "px-2 py-2 whitespace-nowrap text-ellipsis overflow-hidden") if attribute_type == :decimal
-        return div(value, class: "px-2 py-2 whitespace-nowrap text-ellipsis overflow-hidden") if attribute_type != :enum
+        return div(class: "px-2 py-2 whitespace-nowrap text-ellipsis overflow-hidden") { number_with_precision(value, precision: Book.columns_hash[@attribute].sql_type_metadata.scale) } if attribute_type == :decimal
+        return div(class: "px-2 py-2 whitespace-nowrap text-ellipsis overflow-hidden") { value } if attribute_type != :enum
 
-        color = tailwind_color_for_enum
-        div @record.public_send(@attribute).to_s, **classes("inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-medium", tailwind_color_for_enum)
+        div(**classes("inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-medium", tailwind_color_for_enum)) { @record.public_send(@attribute).to_s }
       end
 
       def filtered? = @search.condition_attributes.include? @attribute

--- a/app/views/table/column_summary.rb
+++ b/app/views/table/column_summary.rb
@@ -13,24 +13,24 @@ module Views
             div class: "whitespace-nowrap" do
               input type: "hidden", name: "attribute", value: @attribute
               select name: "calculation", id: "calculation", dir: "rtl", class: "bg-transparent border-transparent rounded text-gray-600 hover:bg-gray-300", data: { action: "change->element#click" }, autocomplete: "off" do
-                option "None", value: "", selected: (@calculation == "")
-                option "Empty", value: "nil", selected: (@calculation == "nil")
-                option "Filled", value: "not_nil", selected: (@calculation == "not_nil")
-                option "Unique", value: "unique", selected: (@calculation == "unique")
-                option "Min", value: "min", selected: (@calculation == "min") if [:numeric, :decimal].include?(attribute_type)
-                option "Max", value: "max", selected: (@calculation == "max") if [:numeric, :decimal].include?(attribute_type)
-                option "Average", value: "avg", selected: (@calculation == "avg") if [:numeric, :decimal].include?(attribute_type)
-                option "Sum", value: "sum", selected: (@calculation == "sum") if [:numeric, :decimal].include?(attribute_type)
-                option "Earliest Date", value: "earliest", selected: (@calculation == "earliest") if [:date, :datetime].include?(attribute_type)
-                option "Latest Date", value: "latest", selected: (@calculation == "latest") if [:date, :datetime].include?(attribute_type)
+                option(value: "", selected: (@calculation == "")) { "None" }
+                option(value: "nil", selected: (@calculation == "nil")) { "Empty" }
+                option(value: "not_nil", selected: (@calculation == "not_nil")) { "Filled" }
+                option(value: "unique", selected: (@calculation == "unique")) { "Unique" }
+                option(value: "min", selected: (@calculation == "min")) { "Min" } if [:numeric, :decimal].include?(attribute_type)
+                option(value: "max", selected: (@calculation == "max")) { "Max" } if [:numeric, :decimal].include?(attribute_type)
+                option(value: "avg", selected: (@calculation == "avg")) { "Average" } if [:numeric, :decimal].include?(attribute_type)
+                option(value: "sum", selected: (@calculation == "sum")) { "Sum" } if [:numeric, :decimal].include?(attribute_type)
+                option(value: "earliest", selected: (@calculation == "earliest")) { "Earliest Date" } if [:date, :datetime].include?(attribute_type)
+                option(value: "latest", selected: (@calculation == "latest")) { "Latest Date" } if [:date, :datetime].include?(attribute_type)
               end
 
-              output @total.to_s, class: "inline-block text-left ml-2"
+              output(class: "inline-block text-left ml-2") { @total.to_s }
             end
             noscript do
               div class: "flex justify-end gap-1" do
                 input type: "reset", value: "Cancel", class: "cursor-pointer inline-flex items-center rounded-md border border-transparent bg-gray-200 px-2 py-1 text-base font-medium text-gray-900 hover:bg-gray-300"
-          
+
                 input type: "submit", value: "Apply", class: "inline-flex items-center rounded-md border border-transparent bg-blue-500 px-2 py-1 text-base font-medium text-white shadow-sm hover:bg-blue-400"
               end
             end
@@ -39,12 +39,12 @@ module Views
           end
         end
       end
-      
+
       private
 
       def attribute_schema = Book.attribute_schema.fetch(@attribute.to_sym)
       def attribute_type = attribute_schema[:type]
-      
+
       def authenticity_token_input
         input type: "hidden",
               name: "authenticity_token",

--- a/app/views/table/footer.rb
+++ b/app/views/table/footer.rb
@@ -14,8 +14,8 @@ module Views
             td colspan: attributes.size + 1 do
               div class: "sticky left-0 flex flex-wrap items-center justify-between py-2 px-4 gap-4 max-w-screen", data_controller: "pagy" do
                 page_items_form
-                raw pagy_nav(@pagy)
-                raw pagy_info(@pagy)
+                unsafe_raw pagy_nav(@pagy)
+                unsafe_raw pagy_info(@pagy)
               end
             end
           end
@@ -30,7 +30,7 @@ module Views
         div data_controller: "element" do
           select name: "page_items", form: "searchForm", id: "page_items", class: "rounded-md border-gray-300 py-2 pl-3 pr-10 text-base focus:border-indigo-500 focus:outline-none focus:ring-indigo-500 sm:text-sm", data: { action: "change->element#click" }, autocomplete: "off" do
             [10, 20, 50, 100].map do |item|
-              option item.to_s, value: item.to_s, selected: Array(params[:page_items]).include?(item.to_s) || Pagy::DEFAULT[:items] == item
+              option(value: item.to_s, selected: Array(params[:page_items]).include?(item.to_s) || Pagy::DEFAULT[:items] == item) { item.to_s }
             end
           end
           noscript do

--- a/app/views/table/group_header.rb
+++ b/app/views/table/group_header.rb
@@ -20,12 +20,12 @@ module Views
               end
               div class: "flex flex-1 items-center justify-between" do
                 div class: "flex flex-col text-left" do
-                  small Book.human_attribute_name(@search.batch_attribute), class: "uppercase font-bold text-gray-600"
-                  span @group_name.to_s, class: "h5 mb-0 whitespace-nowrap"
+                  small(class: "uppercase font-bold text-gray-600") { Book.human_attribute_name(@search.batch_attribute) }
+                  span(class: "h5 mb-0 whitespace-nowrap") { @group_name.to_s }
                 end
                 div class: "space-x-1" do
-                  small "Count", class: "font-normal text-gray-500"
-                  span @group_count.to_s, class: "monospace-numbers inline-flex items-center rounded-full bg-gray-300 px-2.5 py-0.5 text-xs font-medium text-gray-900 monospace-numbers"
+                  small(class: "font-normal text-gray-500") { "Count" }
+                  span(class: "monospace-numbers inline-flex items-center rounded-full bg-gray-300 px-2.5 py-0.5 text-xs font-medium text-gray-900 monospace-numbers") { @group_count.to_s }
                 end
               end
             end

--- a/app/views/table/header.rb
+++ b/app/views/table/header.rb
@@ -9,13 +9,13 @@ module Views
       end
 
       def template
-        th **header_attributes do
+        th(**header_attributes) do
           render MenuComponent.new(**popover_component_props) do |menu|
-            menu.trigger **popover_trigger_attributes do
+            menu.trigger(**popover_trigger_attributes) do
               column_icon
-              span Book.human_attribute_name(@attribute)
+              span { Book.human_attribute_name(@attribute) }
             end
-            menu.portal **popover_portal_attributes do
+            menu.portal(**popover_portal_attributes) do
               menu.group do
                 render MenuItemComponent.new(**sort_asc_menu_item_props)
                 render MenuItemComponent.new(**sort_desc_menu_item_props)
@@ -70,21 +70,21 @@ module Views
           class: "overflow-auto max-h-[calc(100vh-250px)] origin-top-right",
         }
       end
-        
+
       def column_icon
         return render(Bootstrap::IconComponent.new(attribute_icon)) unless sorted?
 
-        span **classes("inline-flex flex-col items-center", -> { sort_dir == "asc" } => "-mt-3", -> { sort_dir == "desc" } => "-mb-3") do
+        span(**classes("inline-flex flex-col items-center", -> { sort_dir == "asc" } => "-mt-3", -> { sort_dir == "desc" } => "-mb-3")) do
           sort_index_indicator
           sort_dir_indicator
         end
       end
-      
+
       def sort_index = @search.sorts.index { |sort| sort.attr_name == @attribute } + 1
       def sort_index_indicator
-        span sort_index.to_s, class: "bg-orange-400 h-5 w-5 p-1 text-xs text-center leading-none rounded-full z-50", id: "SortPriorityColTitle", aria_hidden: "true"
+        span(class: "bg-orange-400 h-5 w-5 p-1 text-xs text-center leading-none rounded-full z-50", id: "SortPriorityColTitle", aria_hidden: "true") { sort_index.to_s }
       end
-      
+
       def sort_dir = @search.sorts.find { |sort| sort.attr_name == @attribute }.dir
       def sort_dir_indicator
         if sort_dir == "asc"

--- a/app/views/table/row.rb
+++ b/app/views/table/row.rb
@@ -9,8 +9,8 @@ module Views
       end
 
       def template
-        tr **classes("row-group hover:bg-gray-100 has-checked:bg-blue-100",
-               -> { !@expanded } => "sr-only"), id: dom_id(@record, :row), data_groupable_target: "row" do
+        tr(**classes("row-group hover:bg-gray-100 has-checked:bg-blue-100",
+               -> { !@expanded } => "sr-only"), id: dom_id(@record, :row), data_groupable_target: "row") do
           select_cell
           attributes.each do |attribute|
             render column_class.new(@record, attribute:, search: @search)
@@ -29,8 +29,8 @@ module Views
       end
 
       def select_cell
-        td class: "text-center relative sticky left-px bg-white w-12 text-sm" do
-          input type: "checkbox",
+        td(class: "text-center relative sticky left-px bg-white w-12 text-sm") do
+          input(type: "checkbox",
                 id: select_identifier,
                 class: "hidden [.row-group:hover_&]:inline-block checked:inline-block peer rounded border-gray-300 text-blue-600 focus:ring-blue-500",
                 name: "select[#{@record.id}]",
@@ -41,8 +41,8 @@ module Views
                 data: {
                   checkbox_set_target: "child",
                   row_checkbox: true
-                }
-          span @record.id.to_s, class: "ml-1 text-gray-600 inline-block [.row-group:hover_&]:hidden peer-checked:hidden"
+                })
+          span(class: "ml-1 text-gray-600 inline-block [.row-group:hover_&]:hidden peer-checked:hidden") { @record.id.to_s }
           label for: select_identifier, class: "absolute inset-0"
           div class: "absolute inset-y-0 left-0 w-1 bg-blue-600 hidden peer-checked:block"
         end


### PR DESCRIPTION
The main changes for upgrading Phlex from 0.2 → 0.5

| Before (0.2) | After (0.5) | Explanation |
| --- | --- | --- |
| `span "Text"` | `span { "Text" }` | You can no longer pass content as a positional <br/> argument.  Instead, you can pass it as a block.  <br/>(See: https://github.com/joeldrapper/phlex/pull/231)|
| `content(&)` | `yield_content(&)` | Method was renamed <br/> (See: https://github.com/joeldrapper/phlex/pull/194 and https://github.com/joeldrapper/phlex/issues/190) |
| `raw method_call` | `unsafe_raw method_call` | Method was renamed to indicate how unsafe it is. <br/> (See: https://github.com/joeldrapper/phlex/pull/308) |
| - | `include Phlex::Rails::Layout` | for `csp_meta_tag` and `csrf_meta_tags` <br/>helpers in layout (See: https://github.com/joeldrapper/phlex/pull/225)|